### PR TITLE
[U] Enhancements to English Translations and Standardization to British English

### DIFF
--- a/people/CuspariaKLSY/page.en.md
+++ b/people/CuspariaKLSY/page.en.md
@@ -29,7 +29,7 @@ If she believes sacrificing herself would benefit others, she won't have a secon
 
 She cares about her friends a lot.
 
-She's a Eastern Orthodox Christian.
+She's an Eastern Orthodox Christian.
 
 She doesn't really trust God 100%, though.
 

--- a/people/Dethelly/page.en.md
+++ b/people/Dethelly/page.en.md
@@ -15,7 +15,7 @@ Moreover, she hadn't a friend to confide her thought, she could only hide these 
 That made her look a bit intimidated.
 
 She always prepared a lot ahead of meeting friends in real life.
-She was always worried about leaving a bad impression, so she asked them tons of questions in advance (such as which kinds of gift they would like), and warned them she might exhibit regressive behaviors.
+She was always worried about leaving a bad impression, so she asked them tons of questions in advance (such as which kinds of gift they would like), and warned them she might exhibit regressive behaviours.
 
 Her family is conservative.
 Her father worked in China Railways Group and her mother was a teacher.
@@ -62,7 +62,7 @@ Later, Sugar began her winter vacation, and got her diagnosis certificate of gen
 
 On January 22nd, 2024, she went back to her hometown, Chongqing, and regained contact with A.
 
-(According to her mother who worked away from Chongqing, when she just returned home, she seemed happy in Wechat.)
+(According to her mother who worked away from Chongqing, when she just returned home, she seemed happy in WeChat.)
 
 But the reality is the opposite.
 
@@ -101,7 +101,7 @@ Her parents started to tidy up her belongings.
 
 Her mother asked A if she wanted to keep Sugar's IKEA Blåhaj Shark, which she loved to hug.
 
-Her mother said, he was their angel, but unfortunately God made him leave early and he had to leave.
+Her mother said, he was their angel, but unfortunately God made him leave early, and he had to leave.
 
 Her mother had always been grateful to A.
 
@@ -134,7 +134,7 @@ In a daze, a phone call from Chongqing came, and she was familiar with the numbe
 > Girl, I am glad you're okay, wish you a happy life.
 
 Sugar had a very cute face and figure.
-If we change a character of her name to another homophonic one, it would became a girl's name that perfectly matches her gentle and soft temperament.
+If we change a character of her name to another homophonic one, it would become a girl's name that perfectly matches her gentle and soft temperament.
 
 But she just departed, with a mentality of "take a gamble".
 Her life was frozen at the age of 19.
@@ -170,7 +170,7 @@ It was a pity that she departed abruptly, without waiting for a turn for the bet
 > 
 > Hope that if you have the ability to call the police, you can dial decisively. You are a lifesaver, not a murderer. Don't be afraid.
 > 
-> Hope you cherishes life, hope still exists; you will only miss the opportunity if you leave too early.
+> Hope you cherish life, hope still exists; you will only miss the opportunity if you leave too early.
 > 
 > Hope you'll all remember Sugar.
 

--- a/people/Dethelly/page.en.md
+++ b/people/Dethelly/page.en.md
@@ -56,7 +56,7 @@ That night, Sugar actually deleted her contact.
 The second day, a Twitter user who claimed to be Sugar's high school classmate brought her some random thoughts on behalf of Sugar.
 Then A requested them to look after her.
 
-Later, Sugar began her winter vacation, and got her diagnosis certificate of gender dysphoria in Shenzhen Kangning Hospital —— This was only known by A after her death.
+Later, Sugar began her winter holiday, and got her diagnosis certificate of gender dysphoria in Shenzhen Kangning Hospital —— This was only known by A after her death.
 
 ## Thick fog over Jialing River (Her departure)
 

--- a/people/Dethelly/page.en.md
+++ b/people/Dethelly/page.en.md
@@ -15,7 +15,7 @@ Moreover, she hadn't a friend to confide her thought, she could only hide these 
 That made her look a bit intimidated.
 
 She always prepared a lot ahead of meeting friends in real life.
-She was always worried about leaving a bad impression, so she asked them tons of questions in advance (such as which kinds of gift they would like), and warned them she might exhibit regressive behaviours.
+She was always worried about leaving a bad impression, so she asked them tons of questions in advance (such as which kinds of gift they would like), and warned them she might exhibit regressive behaviors.
 
 Her family is conservative.
 Her father worked in China Railways Group and her mother was a teacher.

--- a/people/Dethelly/page.en.md
+++ b/people/Dethelly/page.en.md
@@ -56,7 +56,7 @@ That night, Sugar actually deleted her contact.
 The second day, a Twitter user who claimed to be Sugar's high school classmate brought her some random thoughts on behalf of Sugar.
 Then A requested them to look after her.
 
-Later, Sugar began her winter holiday, and got her diagnosis certificate of gender dysphoria in Shenzhen Kangning Hospital —— This was only known by A after her death.
+Later, Sugar began her winter vacation, and got her diagnosis certificate of gender dysphoria in Shenzhen Kangning Hospital —— This was only known by A after her death.
 
 ## Thick fog over Jialing River (Her departure)
 

--- a/people/Futajuhuacha/page.en.md
+++ b/people/Futajuhuacha/page.en.md
@@ -83,7 +83,7 @@ From the first seven day to the seventh seven day[^2] of Xueli's death,
 she always missed Xueli, the lovely gentle girl who quietly left alone.
 
 > May the world treat you gently.
-> 
+>
 > It's suddenly raining heavily in Chongqing...
 >
 > Is this your way of calling me...?
@@ -96,7 +96,7 @@ she almost couldn't control the thought of suicide on the Huanghuayuan Jialingji
 which was a land of fate —— the place of death of Xueli and several other MtFs in Chongqing.
 
 At the end of June, she attempted to take her own life again and was admitted to ICU.
-Afte her physical condition improved, she wrote down this little poem:
+After her physical condition improved, she wrote down this little poem:
 
 <PhotoScroll photos={[
 '${path}/photos/photo1.jpg',

--- a/people/Futajuhuacha/page.en.md
+++ b/people/Futajuhuacha/page.en.md
@@ -11,7 +11,7 @@ Huacha was a lovely and determined trans girl who loved this world.
 
 She was an OIer and once participated in the National Olympiad in Informatics(NOI).
 
-She adored long hair, so she opted for hair extension to fulfil her love for it.
+She adored long hair, so she opted for hair extension to fulfill her love for it.
 
 She loved writing and reading, and she often delved into the works of Lu Xun.
 She showcased her fluency in poetry and her ability to critique the world by writing essays, reminiscent of Lu Xun's style.

--- a/people/Futajuhuacha/page.en.md
+++ b/people/Futajuhuacha/page.en.md
@@ -11,16 +11,16 @@ Huacha was a lovely and determined trans girl who loved this world.
 
 She was an OIer and once participated in the National Olympiad in Informatics(NOI).
 
-She adored long hair, so she opted for hair extension to fulfill her love for it.
+She adored long hair, so she opted for hair extension to fulfil her love for it.
 
 She loved writing and reading, and she often delved into the works of Lu Xun.
 She showcased her fluency in poetry and her ability to critique the world by writing essays, reminiscent of Lu Xun's style.
 
 Realizing her true gender identity at an early age,
 she struggled with severe anxiety,
-which she she endured silently for a long time.
+which she endured silently for a long time.
 She always felt that she was trapped in a nightmare of not being recognized as a girl,
-and she hoped to wake up from it everyday.
+and she hoped to wake up from it every day.
 Later, she chose the path of self-discovery, and embraced her identity as a girl.
 
 Huacha was a gentle girl, akin to her friend [Xuewulihuameng](https://one-among.us/profile/xuewulihuameng).

--- a/people/Futajuhuacha/page.en.md
+++ b/people/Futajuhuacha/page.en.md
@@ -112,7 +112,7 @@ The dreamlike lighting seemed to immerse her in a dream...
 In the same place, a similar night, she took her own life as Xueli did.
 
 The rescue in the late night failed to save her life.
-In the early morning of the next day, The girl chasing the milky way left the world at last.
+In the early morning of the next day, The girl chasing the Milky Way left the world at last.
 
 > Farewell, Huacha. Hope you and Xueli can be together well in heaven.
 >

--- a/people/GLaDOSister/page.en.md
+++ b/people/GLaDOSister/page.en.md
@@ -7,7 +7,7 @@ info:
 
 ## Description
 
-As her bio says, Shizuha is “a cute girl researching lingustics”.
+As her bio says, Shizuha is “a cute girl researching linguistics”.
 
 Shizuha is talented in linguistics and passionate about it.
 She researched many languages, including both languages originated from China and foreign languages.
@@ -20,9 +20,9 @@ She had contributed to the community of the *Half-Life* series.
 She designed some "GMod" plugins and maps; and she was the director of a fanmade work called *Combine Prelude* for *Half-Life 2*.
 The fact that worth mentioning the most is, she started doing constructed language research,
 constructed [Combinese](https://yuyan.fandom.com/zh/wiki/联合军语), [Yupoian](https://yuyan.fandom.com/zh/wiki/尤波伊语) and [Crigàt](https://yuyan.fandom.com/zh/wiki/克里加语) for the project mentioned above, *Combine Prelude*.
-Because of her work on this project, she was famous both in the *Half-Life* community and in the contructed language community.
+Because of her work on this project, she was famous both in the *Half-Life* community and in the constructed language community.
 
-Shizuha's favorite anime is *YuruYuri*.
+Shizuha's favourite anime is *YuruYuri*.
 She used the main character, Akari Akaza, as her profile photo.
 
 Shizuha is persistent and brave, both for creative work and for life, sometimes even stubborn.
@@ -30,7 +30,7 @@ Because of that, she had some verbal conflicts with her friends.
 These incidents were however resolved quickly because of her friends' understanding towards her character.
 
 Shizuha asked for company very often from friends she found in the linguistics community because she didn't feel safe enough.
-Whether online or in real life, she was always gave and seeked warmth from other trans women and girls.
+Whether online or in real life, she was always gave and sought warmth from other trans women and girls.
 
 Since Spring 2019, Shizuha was finally able to pass and live as a woman.
 Because of that, she was much more confident and more open to showing her cuteness by sharing photos on social media.
@@ -43,7 +43,7 @@ In [one of her posts on ZhiHu](https://www.zhihu.com/pin/1091048372731047936), s
 Even now, this sentence still give strength to many suicide prevention social workers.
 Unfortunately, Shizuha eventually left us, leaving behind many unfinished works.
 
-After Shizuha's death, many people in the linguistics community, the constructed language community, and the trans community changed their profile photo to black and white to morun her.
+After Shizuha's death, many people in the linguistics community, the constructed language community, and the trans community changed their profile photo to black and white to mourn her.
 
 Under the ZhiHu question of [What are your thoughts about ZhiHu user @Cang_Shan_Jing_Ye ?](https://www.zhihu.com/question/307482232),
 not only were there goodbyes from the friends she made,

--- a/people/GLaDOSister/page.en.md
+++ b/people/GLaDOSister/page.en.md
@@ -22,7 +22,7 @@ The fact that worth mentioning the most is, she started doing constructed langua
 constructed [Combinese](https://yuyan.fandom.com/zh/wiki/联合军语), [Yupoian](https://yuyan.fandom.com/zh/wiki/尤波伊语) and [Crigàt](https://yuyan.fandom.com/zh/wiki/克里加语) for the project mentioned above, *Combine Prelude*.
 Because of her work on this project, she was famous both in the *Half-Life* community and in the constructed language community.
 
-Shizuha's favourite anime is *YuruYuri*.
+Shizuha's favorite anime is *YuruYuri*.
 She used the main character, Akari Akaza, as her profile photo.
 
 Shizuha is persistent and brave, both for creative work and for life, sometimes even stubborn.

--- a/people/Hangmster/page.en.md
+++ b/people/Hangmster/page.en.md
@@ -11,7 +11,7 @@ Hangmster is our ally.
 
 They often interacted with friends on Twitter/X, bringing us laughter. They gave warm hugs when we needed, consoled us when we were anxious, and mourned for our departed friends.
 
-They seldomly mentioned what they loved. But according to their tweets, they were interested in cute things such as cats. They were fond of Hatsune Miku as well. On the Hatsune Miku 15th anniversary, they expressed their happiness by drawing an illustration:
+They seldom mentioned what they loved. But according to their tweets, they were interested in cute things such as cats. They were fond of Hatsune Miku as well. On the Hatsune Miku 15th anniversary, they expressed their happiness by drawing an illustration:
 
 <PhotoScroll photos={[ '${path}/photos/fufu.jpg',]} />  
 

--- a/people/Katerina/page.en.md
+++ b/people/Katerina/page.en.md
@@ -7,7 +7,7 @@ info:
 
 ## Description
 
-Katerina (Natasha) is a trans woman from Heilongjiang province. She had a variety of interests and hobbies, including Russian, composite bow, weightlifting, aerial photography, and motocycle riding.
+Katerina (Natasha) is a trans woman from Heilongjiang province. She had a variety of interests and hobbies, including Russian, composite bow, weightlifting, aerial photography, and motorcycle riding.
 She also liked liquor; she hoped to open a bar for trans people.
 
 Born in 2003, she always celebrated her birthday on the 27th day of the first lunisolar month.

--- a/people/Kotori/page.en.md
+++ b/people/Kotori/page.en.md
@@ -25,7 +25,7 @@ However, she was passionate about academic questions,
 and she always joined in the discussion and applauded her friends for their neat ideas.
 
 She often deleted her own ideas or works after creating them, or she posted them anonymously.
-Nonetheless, there are still some answers of her remained on Zhihu now, rediating her brilliance.
+Nonetheless, there are still some answers of her remained on Zhihu now, radiating her brilliance.
 
 She was obsessed with her favourite subjects, and achieved that "erudite and Atsushi, cut near the question thinking."
 
@@ -47,7 +47,7 @@ After consulting numerous references to ascertain the lethal dose of the drug,
 she ultimately decided to end her life on the morning of September 24th, 2019.
 
 After that, her friends endeavoured to contact with USTC authorities, and police in Poyang, Shangrao.
-However, due to the lack of of timely treatment, she was unable to recover and left us at last.
+However, due to the lack of timely treatment, she was unable to recover and left us at last.
 
 ## Memorial
 
@@ -59,7 +59,7 @@ Sakura Moeka wrote:
 >
 > But she would never see that.
 
-Her friends perpetually felt a deep longing for her persence.
+Her friends perpetually felt a deep longing for her presence.
 Even the mere sight of the character `∂` evoked profound sorrow within them.
 
 Countless companionships, and stories of getting to know each other had finally become fragments of the past...

--- a/people/Mio/page.en.md
+++ b/people/Mio/page.en.md
@@ -23,7 +23,7 @@ She was admitted to one of the top universities in China because of her brillian
 In life, she liked to play *Minecraft* and *Karbel Space Program*.
 After all these years, she became a gentle big sister to many people.
 
-She sufferred major depression disorder throughout the last year of her life.
+She suffered major depression disorder throughout the last year of her life.
 Although she was pushed to suicide several times, she still tried to live as happily as she could.
 She made many friends and built up many relationships in that year alone:
 
@@ -74,7 +74,7 @@ Translation:
 > 
 > > (Translation of the post):
 > >
-> > To be able to maintain a state between male and female is a miracle――height, body shape, behavior, skin, and voice.
+> > To be able to maintain a state between male and female is a miracle――height, body shape, behaviour, skin, and voice.
 > > A state like this allows me to switch gender presentations relatively easily without fear of being clocked.
 > > Being in a state like this delayed the worsening of my Gender Dysphoria.
 > >

--- a/people/Mio/page.en.md
+++ b/people/Mio/page.en.md
@@ -74,7 +74,7 @@ Translation:
 > 
 > > (Translation of the post):
 > >
-> > To be able to maintain a state between male and female is a miracle――height, body shape, behaviour, skin, and voice.
+> > To be able to maintain a state between male and female is a miracle――height, body shape, behavior, skin, and voice.
 > > A state like this allows me to switch gender presentations relatively easily without fear of being clocked.
 > > Being in a state like this delayed the worsening of my Gender Dysphoria.
 > >

--- a/people/Mio/page.en.md
+++ b/people/Mio/page.en.md
@@ -62,7 +62,7 @@ Translation:
 >
 > Mio: Is it because you saw my Tieba (Translator's note: a popular social media platform) post?
 >
-> Me: No, I haven't checked Tieba in a while. I did see your Wechat (Translator's note: another popular social media platform) post, though.
+> Me: No, I haven't checked Tieba in a while. I did see your WeChat (Translator's note: another popular social media platform) post, though.
 > 
 > Me: Have you considered what you're experiencing to be Gender Dysphoria?
 > 
@@ -70,7 +70,7 @@ Translation:
 > 
 > Me: I think we need to meet. How about May 1st? (Translator's note: a holiday)
 > 
-> Me: (photo, a Wechat post)
+> Me: (photo, a WeChat post)
 > 
 > > (Translation of the post):
 > >

--- a/people/Mio/page.en.md
+++ b/people/Mio/page.en.md
@@ -37,7 +37,7 @@ In 2022 April, [Bei Yan Yun Yi](https://github.com/BeiyanYunyi) saw a social med
 It was also at that time that Bei Yan Yun Yi figured out her gender identity.
 Bei Yan Yun Yi remembered that Mio had done research on SRS during primary school.
 Therefore, when she reconnected with Mio, she came out to her.
-Just like that, best "boy" friends become best girl friends.
+Just like that, best "boy" friends became best girl friends.
 
 <PhotoScroll photos={[
 '${path}/photos/photo6.jpg',

--- a/people/MioCardMeow/page.en.md
+++ b/people/MioCardMeow/page.en.md
@@ -35,7 +35,7 @@ SugarMeow said, in fact, MioCardMeow was in fact a clingy girl. It was a pity th
 
 Her hostile family and negative impact of long-term medication (pituitary adenoma) gave rise to her suicidal thoughts. She passed away after an unsuccessful resuscitation.
 
-Her departure was reported by [Miao Xiao Bai](https://twitter.com/pizyj/status/1492928433172582400?s=21) on Feburary 14th, 2022.
+Her departure was reported by [Miao Xiao Bai](https://twitter.com/pizyj/status/1492928433172582400?s=21) on February 14th, 2022.
 
 ## After Her Leaving
 

--- a/people/MizuharaNagisa/page.en.md
+++ b/people/MizuharaNagisa/page.en.md
@@ -16,7 +16,7 @@ Her hobbies were tinkering with computer hardware like Raspberry Pi and drawing.
 She was also proficient in Japanese.
 
 Because of depression and other problems, she had to stop going to school since 2019;
-because of unacceptance from her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
+because of unacceptance of her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
 On 2021 July 21st, she took her own life to leave this cruel world.
 
 This is the [last piece of writing](https://pbs.twimg.com/media/E6odBBBVIAAM-Zt?format=jpg&name=4096x4096) she left us.

--- a/people/MizuharaNagisa/page.en.md
+++ b/people/MizuharaNagisa/page.en.md
@@ -16,7 +16,7 @@ Her hobbies were tinkering with computer hardware like Respberry Pi and drawing.
 She was also proficient in Japanese.
 
 Because of depression and other problems, she had to stop going to school since 2019;
-because of inacceptance of her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
+because of lack of understanding from her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
 On 2021 July 21st, she took her own life to leave this cruel world.
 
 This is the [last piece of writing](https://pbs.twimg.com/media/E6odBBBVIAAM-Zt?format=jpg&name=4096x4096) she left us.

--- a/people/MizuharaNagisa/page.en.md
+++ b/people/MizuharaNagisa/page.en.md
@@ -12,7 +12,7 @@ She was friends with [Ying](https://www.one-among.us/profile/Uekawakuyuurei/).
 During her life, she was an active long-term contributor for Chinese Wikipedia and other MediaWiki sites.
 Since 2019, she started playing *Kancolle*.
 Her favourite character was Destroyer Hibiki.
-Her hobbies were tinkering with computer hardware like Respberry Pi and drawing.
+Her hobbies were tinkering with computer hardware like Raspberry Pi and drawing.
 She was also proficient in Japanese.
 
 Because of depression and other problems, she had to stop going to school since 2019;

--- a/people/MizuharaNagisa/page.en.md
+++ b/people/MizuharaNagisa/page.en.md
@@ -31,7 +31,7 @@ This is the [last piece of writing](https://pbs.twimg.com/media/E6odBBBVIAAM-Zt?
 > so I decided to end my life.
 > I don't really know what would happen,
 > either I'd be dead or I'd be in the ICU, lol.
-> Regrettablly, I would be unable to enjoy the 3060 video card I just got.
+> Regrettably, I would be unable to enjoy the 3060 video card I just got.
 > And Nintendo Switch, PlayStation 5.
 >
 > Everything goes wrong when my family is involved.

--- a/people/MizuharaNagisa/page.en.md
+++ b/people/MizuharaNagisa/page.en.md
@@ -16,7 +16,7 @@ Her hobbies were tinkering with computer hardware like Raspberry Pi and drawing.
 She was also proficient in Japanese.
 
 Because of depression and other problems, she had to stop going to school since 2019;
-because of lack of understanding from her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
+because of unacceptance from her family and other problems she faced, her depression and anxiety got worse and started to suffer from insomnia.
 On 2021 July 21st, she took her own life to leave this cruel world.
 
 This is the [last piece of writing](https://pbs.twimg.com/media/E6odBBBVIAAM-Zt?format=jpg&name=4096x4096) she left us.

--- a/people/Mizuki_Yuuki/page.en.md
+++ b/people/Mizuki_Yuuki/page.en.md
@@ -22,8 +22,8 @@ My heart was filled with endless mourning and sorrow.
 In early December, when Mizuki got their first Kigurumi headpiece, they were overjoyed and felt liberated.
 Three days later, I invited them for an outdoor photoshoot in Century Park – my first outdoor photoshoot.
 
-After this photoshoot, Mizuki organized a Kigurumi party and travelled twice: one to Kuala Lumpur before Christmas, and another to Hong Kong after New Year's Day.
-They were not fond of travelling, so that was a bit surprising.
+After this photoshoot, Mizuki organized a Kigurumi party and traveled twice: one to Kuala Lumpur before Christmas, and another to Hong Kong after New Year's Day.
+They were not fond of traveling, so that was a bit surprising.
 
 Then they left this world.
 Perhaps it was financial troubles that overwhelmed them, or maybe they had fulfilled all their wishes.

--- a/people/Mizuki_Yuuki/page.en.md
+++ b/people/Mizuki_Yuuki/page.en.md
@@ -22,8 +22,8 @@ My heart was filled with endless mourning and sorrow.
 In early December, when Mizuki got their first Kigurumi headpiece, they were overjoyed and felt liberated.
 Three days later, I invited them for an outdoor photoshoot in Century Park – my first outdoor photoshoot.
 
-After this photoshoot, Mizuki organized a Kigurumi party and traveled twice: one to Kuala Lumpur before Christmas, and another to Hong Kong after New Year's Day.
-They were not fond of traveling so that was a bit surprising.
+After this photoshoot, Mizuki organized a Kigurumi party and travelled twice: one to Kuala Lumpur before Christmas, and another to Hong Kong after New Year's Day.
+They were not fond of travelling, so that was a bit surprising.
 
 Then they left this world.
 Perhaps it was financial troubles that overwhelmed them, or maybe they had fulfilled all their wishes.

--- a/people/Xu_Yushu/page.en.md
+++ b/people/Xu_Yushu/page.en.md
@@ -128,7 +128,7 @@ After listening to the advice of the doctor, he told Xu Yushu "Try to forget it,
 Xu Yushu's father actually always tried to understand Xu Yushu.
 He learnt psychology in university but was never taught anything about gender.
 He didn't think his child really had gender dysphoria.
-He said Xu Yushu "never had any weird behaviours" at home,
+He said Xu Yushu "never had any weird behaviors" at home,
 "didn't cry for feminine clothing or wigs", and was only wanting to be a girl because she wanted to have people to protect her from all that bullying,
 
 After her departure, her father still used male pronouns to refer to Xu Yushu, and seldom talked about her desire of being a girl.

--- a/people/Xu_Yushu/page.en.md
+++ b/people/Xu_Yushu/page.en.md
@@ -20,14 +20,14 @@ Maybe it's more accurate to describe her as *literary girl*.
 
 One of Xu Yushu's ambitions is to be accepted by the people around her as a "real" girl.
 
-Xu Yushu had always been a lonely child but she made friends with books.
+Xu Yushu had always been a lonely child, but she made friends with books.
 Reading made her mature faster than her peers.
 She loved being immersed in the world of books.
 Her bookshelf was filled up already at that time.
 Not only that, she also went to the bookstore next to her father's workspace and left a deep impression on the bookstore's manager.
 
 During her high school years, Nan'an Wanda Plaza's Sisyphe Books was one of the places she went to the most.
-There, she could find tranquility in the pleasant smell of coffee and books.
+There, she could find tranquillity in the pleasant smell of coffee and books.
 
 She loved writing, and was once elected as the president of Chongqing No.2 Foreign Language School Nanlu Literary Club.
 In one of her writings, she wrote "Real writing is offering the writer themselves to Goddess Muses's sacrificial altar."
@@ -128,10 +128,10 @@ After listening to the advice of the doctor, he told Xu Yushu "Try to forget it,
 Xu Yushu's father actually always tried to understand Xu Yushu.
 He learnt psychology in university but was never taught anything about gender.
 He didn't think his child really had gender dysphoria.
-He said Xu Yushu "never had any weird behaviors" at home,
+He said Xu Yushu "never had any weird behaviours" at home,
 "didn't cry for feminine clothing or wigs", and was only wanting to be a girl because she wanted to have people to protect her from all that bullying,
 
-After her departure, her father still used male pronouns to refer to Xu Yushu, and seldomly talked about her desire of being a girl.
+After her departure, her father still used male pronouns to refer to Xu Yushu, and seldom talked about her desire of being a girl.
 Obviously, Xu Yushu's father didn't have an accurate grasp of knowledge about gender (maybe because the textbook he read were outdated, maybe because he doesn't want to believe his child is transgender), and he didn't realize gender dysphoria was a major part of Xu Yushu's pressure.
 While she needed support from her family the most, he failed as a core family member.
 
@@ -140,14 +140,14 @@ Maybe in another world, she would've persisted to walk through the darkness and 
 
 ### About Her Friends
 
-ALthough Xu Yushu was always misunderstood and bullied by people around her, she still had her share of friends.
+Although Xu Yushu was always misunderstood and bullied by people around her, she still had her share of friends.
 
 On top of her desk is a deck of playing cards her classmate sent her.
 The cards are old and some of them are tattered.
 In the will she wrote specifically to this classmate, she called him her best friend.
 She also listed a few other friends, and wrote:
 
-> Thank you for being my friends, even though it might be one sided from me.
+> Thank you for being my friends, even though it might be one-sided from me.
 
 ## Conclusion
 

--- a/people/Xu_Yushu/page.en.md
+++ b/people/Xu_Yushu/page.en.md
@@ -27,7 +27,7 @@ Her bookshelf was filled up already at that time.
 Not only that, she also went to the bookstore next to her father's workspace and left a deep impression on the bookstore's manager.
 
 During her high school years, Nan'an Wanda Plaza's Sisyphe Books was one of the places she went to the most.
-There, she could find tranquillity in the pleasant smell of coffee and books.
+There, she could find tranquility in the pleasant smell of coffee and books.
 
 She loved writing, and was once elected as the president of Chongqing No.2 Foreign Language School Nanlu Literary Club.
 In one of her writings, she wrote "Real writing is offering the writer themselves to Goddess Muses's sacrificial altar."

--- a/people/Zha_Ke/page.en.md
+++ b/people/Zha_Ke/page.en.md
@@ -84,5 +84,5 @@ Zha Ke (Lilith) was a transgender man. We have little information of him, only a
 
 <PhotoScroll photos={[ '${path}/photos/letter.jpg']} />
 
-He wrote, “The world abandoned me long ago. I will also eventually be forgotten by everyone.” However, we will remember him forever. We are grateful that the owner of [StarTransForEve](https://startransforeve.com/) provided his information for our rememberance.
+He wrote, “The world abandoned me long ago. I will also eventually be forgotten by everyone.” However, we will remember him forever. We are grateful that the owner of [StarTransForEve](https://startransforeve.com/) provided his information for our remembrance.
 Rest in peace, Zha Ke

--- a/people/a2581911655/page.en.md
+++ b/people/a2581911655/page.en.md
@@ -34,7 +34,7 @@ During the time, she came to Guangdong, and got into [Yantian](https://one-among
 
 After that, she arrived in Shanghai, Zhejiang, and Henan, and met with many friends.
 
-On January 18th, 2024, she ended her journey reluctantly and said that she won't able to see everyone agin until one and a half year later. 
+On January 18th, 2024, she ended her journey reluctantly and said that she won't able to see everyone again until one and a half year later. 
 
-But she couldn't fulfill her appointment. 
+But she couldn't fulfil her appointment. 
 The farewell is a life and death parted. Two days later, she attempted to take her life, and finally left us forever.

--- a/people/a2581911655/page.en.md
+++ b/people/a2581911655/page.en.md
@@ -36,5 +36,5 @@ After that, she arrived in Shanghai, Zhejiang, and Henan, and met with many frie
 
 On January 18th, 2024, she ended her journey reluctantly and said that she won't able to see everyone again until one and a half year later. 
 
-But she couldn't fulfil her appointment. 
+But she couldn't fulfill her appointment. 
 The farewell is a life and death parted. Two days later, she attempted to take her life, and finally left us forever.

--- a/people/akasa_musha/page.en.md
+++ b/people/akasa_musha/page.en.md
@@ -8,11 +8,11 @@ Yuxue is a person who craves companionship, which was often mentioned in her twe
 
 She had the side of being a little girl. She used to decorate mangoes with candles. She also did some research on electronics.
 
-Her parents expressed serious disapproval of her transgender behavior at first, but eventually gained a little understanding of her after her efforts. Like other Chinese schools, her school prevented her from carrying HRT medicines to school and keeping her hair long, which may have exacerbated her depression.
+Her parents expressed serious disapproval of her transgender behaviour at first, but eventually gained a little understanding of her after her efforts. Like other Chinese schools, her school prevented her from carrying HRT medicines to school and keeping her hair long, which may have exacerbated her depression.
 
 It is a pity that her friends’ efforts did not stop her depression from worsening.
 In the end, she chose suicide.
 
-After her death, Han Lianyi (a Chinese trans women known for her volunteer suicide prevention work) reflected on her failure to transfer Yuxue to someone else in time when Han was not capable enough for her case; failing to discover Yuxue's obvious signs of suicide in time; and her inadequacy in guiding the rescue of Yuxue at hospital. Han hopes that this failure could help guide future suicide prevention efforts.
+After her death, Han Lianyi (a Chinese transwoman known for her volunteer suicide prevention work) reflected on her failure to transfer Yuxue to someone else in time when Han was not capable enough for her case; failing to discover Yuxue's obvious signs of suicide in time; and her inadequacy in guiding the rescue of Yuxue at hospital. Han hopes that this failure could help guide future suicide prevention efforts.
 
 May Yuxue become a beautiful girl and never be discriminated against in heaven.

--- a/people/akasa_musha/page.en.md
+++ b/people/akasa_musha/page.en.md
@@ -8,7 +8,7 @@ Yuxue is a person who craves companionship, which was often mentioned in her twe
 
 She had the side of being a little girl. She used to decorate mangoes with candles. She also did some research on electronics.
 
-Her parents expressed serious disapproval of her transgender behaviour at first, but eventually gained a little understanding of her after her efforts. Like other Chinese schools, her school prevented her from carrying HRT medicines to school and keeping her hair long, which may have exacerbated her depression.
+Her parents expressed serious disapproval of her transgender behavior at first, but eventually gained a little understanding of her after her efforts. Like other Chinese schools, her school prevented her from carrying HRT medicines to school and keeping her hair long, which may have exacerbated her depression.
 
 It is a pity that her friends’ efforts did not stop her depression from worsening.
 In the end, she chose suicide.

--- a/people/akasa_musha/page.en.md
+++ b/people/akasa_musha/page.en.md
@@ -13,6 +13,6 @@ Her parents expressed serious disapproval of her transgender behavior at first, 
 It is a pity that her friends’ efforts did not stop her depression from worsening.
 In the end, she chose suicide.
 
-After her death, Han Lianyi (a Chinese transwoman known for her volunteer suicide prevention work) reflected on her failure to transfer Yuxue to someone else in time when Han was not capable enough for her case; failing to discover Yuxue's obvious signs of suicide in time; and her inadequacy in guiding the rescue of Yuxue at hospital. Han hopes that this failure could help guide future suicide prevention efforts.
+After her death, Han Lianyi (a Chinese trans woman known for her volunteer suicide prevention work) reflected on her failure to transfer Yuxue to someone else in time when Han was not capable enough for her case; failing to discover Yuxue's obvious signs of suicide in time; and her inadequacy in guiding the rescue of Yuxue at hospital. Han hopes that this failure could help guide future suicide prevention efforts.
 
 May Yuxue become a beautiful girl and never be discriminated against in heaven.

--- a/people/dogesir_/page.en.md
+++ b/people/dogesir_/page.en.md
@@ -24,7 +24,7 @@ Here are some of her drawings before she left:
     '${path}/photos/works6.jpg',
 ]} />
 
-This is her last self description:
+This is her last self-description:
 
 > “I don't think I'm going to change it for several months because I poured lots of effort into it”
 
@@ -97,6 +97,6 @@ Wish you not lonely on the train. And remember: Look at the star Betelgeuse one 
 {/*
 Comments from the translator:
 
-Please, don&apos;t romantize suicid&#33; I'm begging you&#33;
+Please, don&apos;t romanticize suicide&#33; I'm begging you&#33;
 All of you.
 */}

--- a/people/donotexist_A/page.en.md
+++ b/people/donotexist_A/page.en.md
@@ -42,7 +42,7 @@ Exist has too many good qualities to list.
 
 Exist helped many trans people in Guangdong to build up confidence by using her social media.
 She shared her experience of how she was able to get a diagnosis of gender dysphoria and get the prescriptions with everyone.
-We believe, if we are able to see Exist one more time, she would share all she saw and learnt during her time in the other world with us.
+We believe, if we are able to see Exist one more time, she would share all she saw and learned during her time in the other world with us.
 
 In 2021, May, Exist died of the low blood pressure caused by medication side effects and complications.
 Good night, Exist.

--- a/people/lintong/page.en.md
+++ b/people/lintong/page.en.md
@@ -9,7 +9,7 @@ info:
 
 > Lin Tong is a girl who is a bit insecure.
 > She has a mother who she rarely contacts.
-> Dishes like “scrambled eggs with tomatoes” were her favourites.
+> Dishes like “scrambled eggs with tomatoes” were her favorites.
 > Monster Energy was her drink of choice.
 > Personality wise,
 > her tendency to ask others to do things when they are not in the mood for it was the most notable.

--- a/people/lintong/page.en.md
+++ b/people/lintong/page.en.md
@@ -11,7 +11,7 @@ info:
 > She has a mother who she rarely contacts.
 > Dishes like “scrambled eggs with tomatoes” were her favorites.
 > Monster Energy was her drink of choice.
-> Personality wise,
+> Personalitywise,
 > her tendency to ask others to do things when they are not in the mood for it was the most notable.
 > Acts like a princess sometimes.
 > Likes to trouble her partner but not her friends.

--- a/people/lintong/page.en.md
+++ b/people/lintong/page.en.md
@@ -11,7 +11,7 @@ info:
 > She has a mother who she rarely contacts.
 > Dishes like “scrambled eggs with tomatoes” were her favourites.
 > Monster Energy was her drink of choice.
-> Personalitywise,
+> Personality wise,
 > her tendency to ask others to do things when they are not in the mood for it was the most notable.
 > Acts like a princess sometimes.
 > Likes to trouble her partner but not her friends.

--- a/people/lintong/page.en.md
+++ b/people/lintong/page.en.md
@@ -9,7 +9,7 @@ info:
 
 > Lin Tong is a girl who is a bit insecure.
 > She has a mother who she rarely contacts.
-> Dishes like “scrambled eggs with tomatoes” were her favorites.
+> Dishes like “scrambled eggs with tomatoes” were her favourites.
 > Monster Energy was her drink of choice.
 > Personalitywise,
 > her tendency to ask others to do things when they are not in the mood for it was the most notable.

--- a/people/lxy/page.en.md
+++ b/people/lxy/page.en.md
@@ -9,7 +9,7 @@ Xiyin was an outstanding transgender woman. She was cute and gentle. She was a s
 
 She worked hard at college. Since her relationship with her family was bad, she hoped to support herself through part-time jobs and internships and also save funds for sex reassignment surgery. However, COVID-19 had seriously hindered her pace, causing her to fall into financial difficulties. This may be one of the reasons why she chose to commit suicide.
 
-She also wants to be like a little girl who can’t be bothered to make an effort and needs company occationally. However, because of her identification (MtF) and the society’s increasing atomization, she had always been lonely. Her loneliness was increasingly magnified as both her and her MtF friend developed serious mental problems.
+She also wants to be like a little girl who can’t be bothered to make an effort and needs company occasionally. However, because of her identification (MtF) and the society’s increasing atomization, she had always been lonely. Her loneliness was increasingly magnified as both her and her MtF friend developed serious mental problems.
 
 Her death caught people off guard. The night before, she had a simple dinner with some people in the school club. She was concerned about the issue of the family district in the school at that time[^1], but she wasn’t able to see the issue resolved. We didn't learn of her committing suicide until her dormitory was surrounded by police.
 

--- a/people/mone/page.en.md
+++ b/people/mone/page.en.md
@@ -9,9 +9,9 @@ info:
 
 Mone is a cisgender ally among us. She's quite a cute little girl.
 
-She loves idol groups and singing tv programmes in Japan and South Korea, and often reposts their tweets.
+She loves idol groups and singing TV programmes in Japan and South Korea, and often reposts their tweets.
 
-She also plays Minecraft. In that game, she built a small villa with a cozy room belonging to herself.
+She also plays Minecraft. In that game, she built a small villa with a cosy room belonging to herself.
 
 According to Mone, she never got happiness and love. Her parents got divorced in the first half of 2023. After that, she lived with her mother. The lack of love from family made her depressed. During the past 7 months, her father always refused to visit her, and her paternal grandmother didn't care about her any more. She was treated for depression in hospital. It was a period she missed, because she received lots of love from other patients:
 

--- a/people/mone/page.en.md
+++ b/people/mone/page.en.md
@@ -11,7 +11,7 @@ Mone is a cisgender ally among us. She's quite a cute little girl.
 
 She loves idol groups and singing TV programmes in Japan and South Korea, and often reposts their tweets.
 
-She also plays Minecraft. In that game, she built a small villa with a cosy room belonging to herself.
+She also plays Minecraft. In that game, she built a small villa with a cozy room belonging to herself.
 
 According to Mone, she never got happiness and love. Her parents got divorced in the first half of 2023. After that, she lived with her mother. The lack of love from family made her depressed. During the past 7 months, her father always refused to visit her, and her paternal grandmother didn't care about her any more. She was treated for depression in hospital. It was a period she missed, because she received lots of love from other patients:
 

--- a/people/qianyuanakg/page.en.md
+++ b/people/qianyuanakg/page.en.md
@@ -56,7 +56,7 @@ In her last moment, she still thought of everyone in her will:
 >
 > Your opinions toward me are not important, because I had loved you. I loved you all very much.
 >
-> I put my last words in my heart, because I am afraid others hear that. I want to tell those who had accompanied with me and assisted me, I am so sorry...
+> I put my last words in my heart, because I am afraid others hear that. I want to tell those who have accompanied me and assisted me, I am so sorry...
 >
 > — Extracted from Qianyuan's will
 

--- a/people/qianyuanakg/page.en.md
+++ b/people/qianyuanakg/page.en.md
@@ -22,7 +22,7 @@ Interestingly, she has a lovely sister who bites others (playfully and harmlessl
 I met Qianyuan in November 2022. In my impression, she was a lively high-school student. 
 
 She had dishevelled hair of medium length, which grew over her ears and nearly covered her eyes.
-She always wore a light gray scarf and a light green coat coat.
+She always wore a light grey scarf and a light green coat.
 She was truly an adorable child.
 
 Since we first met online, she'd said that she wanted to played with me.
@@ -38,7 +38,7 @@ She was a very gentle girl. She would listen and respond carefully when you shar
 In addition, she always pleaded us not to overdose, and half jokingly told us not to become "bad girls". 
 
 Her departure was the most regretful and sad thing I learnt in the transgender community.
-I might had a chance to persuade her and play with her...
+I might have had a chance to persuade her and play with her...
 
 ## Departure
 

--- a/people/qianyuanakg/page.en.md
+++ b/people/qianyuanakg/page.en.md
@@ -22,7 +22,7 @@ Interestingly, she has a lovely sister who bites others (playfully and harmlessl
 I met Qianyuan in November 2022. In my impression, she was a lively high-school student. 
 
 She had dishevelled hair of medium length, which grew over her ears and nearly covered her eyes.
-She always wore a light grey scarf and a light green coat.
+She always wore a light gray scarf and a light green coat.
 She was truly an adorable child.
 
 Since we first met online, she'd said that she wanted to played with me.

--- a/people/qiqi233345/page.en.md
+++ b/people/qiqi233345/page.en.md
@@ -1,7 +1,7 @@
 ---
 name: Qi
 ---
-Qi didn’t often talk on the Internet, but she was very welcoming in real life. Her humour always brought people around her happiness.
+Qi didn’t often talk on the Internet, but she was very welcoming in real life. Her humor always brought people around her happiness.
 
 She seemed mysterious. She didn’t often introduce herself because she thinks: “I am me, I want you know me for who I am, not know me as someone with a certain label. If someone can’t understand me, that’s their problem. I don’t want them to hate people who have the same label or experience as me because of me.”
 

--- a/people/qiqi233345/page.en.md
+++ b/people/qiqi233345/page.en.md
@@ -1,7 +1,7 @@
 ---
 name: Qi
 ---
-Qi didn’t often talk on the Internet, but she was very welcoming in real life. Her humor always brought people around her happiness.
+Qi didn’t often talk on the Internet, but she was very welcoming in real life. Her humour always brought people around her happiness.
 
 She seemed mysterious. She didn’t often introduce herself because she thinks: “I am me, I want you know me for who I am, not know me as someone with a certain label. If someone can’t understand me, that’s their problem. I don’t want them to hate people who have the same label or experience as me because of me.”
 
@@ -9,7 +9,7 @@ Qi was a gentle, brave, and resolute person who dares to love and hate. She woul
 
 However, she was also plagued by depression and anxiety.
 
-On March 14, 2023, she attempted suicide by jumping off a building due to depression, and her legs were disabled. This made her life very inconvenient and she became more depressed.
+On March 14, 2023, she attempted suicide by jumping off a building due to depression, and her legs were disabled. This made her life very inconvenient, and she became more depressed.
 
 On July 1, 2023, she jumped off a building again after taking a large amount of antidepressant drugs.
 This time, her injuries were beyond saving.
@@ -17,6 +17,6 @@ This time, her injuries were beyond saving.
 Qi chose to jump off the building due to the suicide of her childhood friend by jumping off a building. She always regretted not being able to save him, so she chose the same way to end her own life.
 
 Qi wrote in her suicide note:
-“My death has nothing to do with anyone, it’s just a choice of mine, please don′t hate others for it. Please live a good, sunny and happy life, and please live a good life for yourself.”
+“My death has nothing to do with anyone, it’s just a choice of mine, please don't hate others for it. Please live a good, sunny and happy life, and please live a good life for yourself.”
 
 She had always hoped that everyone can live happily and healthily.

--- a/people/qiqi233345/page.en.md
+++ b/people/qiqi233345/page.en.md
@@ -17,6 +17,6 @@ This time, her injuries were beyond saving.
 Qi chose to jump off the building due to the suicide of her childhood friend by jumping off a building. She always regretted not being able to save him, so she chose the same way to end her own life.
 
 Qi wrote in her suicide note:
-“My death has nothing to do with anyone, it’s just a choice of mine, please don't hate others for it. Please live a good, sunny and happy life, and please live a good life for yourself.”
+“My death has nothing to do with anyone, it’s just a choice of mine, please don′t hate others for it. Please live a good, sunny and happy life, and please live a good life for yourself.”
 
 She had always hoped that everyone can live happily and healthily.

--- a/people/yingying/page.en.md
+++ b/people/yingying/page.en.md
@@ -1,6 +1,9 @@
 ---
 name: Yingying
 ---
+
+## Description
+
 Yingying is a trans woman who had undergone sex reassignment surgery. She was a lively and cheerful girl who was interested in electronics and chemistry. She looks very handsome when she rides a bicycle. She always brought happiness to those around her. She had a toothpaste box with the Intel Logo at home. She said that every time people enter her bathroom, that toothpaste box made them laugh. [^1]
 
 She had published a lot of articles and videos about electronics in both her personal Bilibili account and the Bilibili account “Geek Lab” she created. She had also posted some videos about motorcycle riding. She also opened a store on Taobao where she sold and rented out electronics. She hoped to go to Guangzhou to develop her career.

--- a/people/yingying/page.en.md
+++ b/people/yingying/page.en.md
@@ -7,7 +7,7 @@ She had published a lot of articles and videos about electronics in both her per
 
 It's a pity that all this stopped abruptly when she lost her life forever in a car accident.
 
-May she still have the same cheerfulness and passion to do what she want to do in her next world! [^1]
+May she still have the same cheerfulness and passion to do what she wanted to do in her next world! [^1]
 
 References
 

--- a/people/yumao/page.en.md
+++ b/people/yumao/page.en.md
@@ -33,7 +33,7 @@ She made wishes to meteors occasionally. She said: "It's not because I believe t
 According to Neko, Yumao loved spicy hot pot, and always enjoyed it with rice.
 
 Yumao liked to watch stars while waiting to fall asleep at night.
-After she returned to China, due to bad weather and few spare time, she couldn't watch stars as often as she did.
+After she returned to China, due to bad weather and fewer spare time, she couldn't watch stars as often as she did.
 So [she made a special trip to Dishui Lake and watched stars](https://web.archive.org/web/20210517104313/https://oao.moe/archives/834/).
 
 She saved many thoughts in her [blog](https://web.archive.org/web/20210420170241/https://oao.moe/archives/), and these blog posts spanned many subjects: computer science, military and politics.
@@ -44,7 +44,7 @@ Of course, she also recorded daily life in her blog, and we can still see her st
 
 Yumao once studied abroad in the US, then she went back to Shanghai to continue her study in university.
 
-In 2017, she encountered Neko in Twitter (Now X), and she felt that Neko was skilled and powerful.
+In 2017, she encountered Neko on Twitter (Now X), and she felt that Neko was skilled and powerful.
 After that, they became close partners.
 
 In that period, there was not so much censorship about transgender topic in Zhihu.
@@ -52,7 +52,7 @@ So Yumao always @ Neko in relevant topics, then showed their affection in public
 
 During that time, Yumao got many mental supports. She described the care from Neko like this:
 
-> "Even those things were dark and painful, which had been hidden, you still observed and felt them. Maybe you understanded more then myself. How wonderful... You also found my scattered identity, then lifted me out of abyss. That was the first time I was been touched by others."
+> "Even those things were dark and painful, which had been hidden, you still observed and felt them. Maybe you understood more than myself. How wonderful... You also found my scattered identity, then lifted me out of abyss. That was the first time I was touched by others."
 
 However, they were forced to separate.
 After that, Neko was brought back to Yunnan by family, and was sent to correctional school (a "school" which uses punishments on students to force them to conform).
@@ -82,7 +82,7 @@ The next day, she left this world with regrets at her age of 17.
 
 > Wish that I could become a pretty girl who is kind-hearted, and become the sister of Ayaka and Ruri.
 
-In her blog post *[Separation and Reunion](https://web.archive.org/web/20210517104118/https://oao.moe/archives/948/)* published in march, she left many words to her friends, and thanked to their company all along. 
+In her blog post *[Separation and Reunion](https://web.archive.org/web/20210517104118/https://oao.moe/archives/948/)* published in March, she left many words to her friends, and thanked to their company all along. 
 
 <PhotoScroll photos={[
     '${path}/photos/photo1.jpg',

--- a/people/yumao/page.en.md
+++ b/people/yumao/page.en.md
@@ -33,7 +33,7 @@ She made wishes to meteors occasionally. She said: "It's not because I believe t
 According to Neko, Yumao loved spicy hot pot, and always enjoyed it with rice.
 
 Yumao liked to watch stars while waiting to fall asleep at night.
-After she returned to China, due to bad weather and fewer spare time, she couldn't watch stars as often as she did.
+After she returned to China, due to bad weather and few spare time, she couldn't watch stars as often as she did.
 So [she made a special trip to Dishui Lake and watched stars](https://web.archive.org/web/20210517104313/https://oao.moe/archives/834/).
 
 She saved many thoughts in her [blog](https://web.archive.org/web/20210420170241/https://oao.moe/archives/), and these blog posts spanned many subjects: computer science, military and politics.

--- a/people/yumao/page.en.md
+++ b/people/yumao/page.en.md
@@ -130,7 +130,7 @@ On 1st September 2019, Neko left Haohaizi, and started her new life after a peri
 >
 > From 2018-03-16 22:31
 >
-> To  2020-03-16 22:31
+> To 2020-03-16 22:31
 >
 > Thanks to all your efforts in that period
 >


### PR DESCRIPTION
Firstly, I want to express my deep appreciation for the incredible work you have done with this website. Reading the stories on this site has profoundly moved me, and I have shed tears multiple times. The memorials serve as a powerful reminder of the struggles of the transgender community, and your dedication to preserving these memories is commendable.

I have made several updates to the English translations on your site. While I am not a native Chinese speaker and possess only a very basic understanding of Mandarin Chinese, I have done my utmost to enhance the English content. Here are the details of my contributions:

- Improved translation and corrected non-existent words.
- Fixed various spelling mistakes.
- Standardised capitalisation and grammar.
- Updated American English wording to British English for consistency.

Rationale for British English:
I believe British English is a more appropriate standard for the site, as it is widely understood globally and provides a sense of formality and respect that aligns well with the solemn and respectful nature of a memorial website. British English is also commonly used in international publications, which may help in reaching a broader audience.

Intentional Retention of Original Wording:
On some pages, I have intentionally not fixed certain grammatical errors or mistranslations. I felt that changing too many words of the deceased could be seen as disrespectful, so I kept these alterations to a very minor amount to preserve the original sentiment as much as possible.

If you need any further feedback or revisions, please do not hesitate to reach out. I am eager to contribute to this meaningful project and am open to any suggestions or additional changes you might have.