### PR TITLE
[F] Fix typo

### DIFF
--- a/data/eggs.json
+++ b/data/eggs.json
@@ -98,7 +98,7 @@
     "userid": [
       "SevenBird",
       "Considerate_cat",
-      "tttsuuukikoo_",
+      "ttttsuuukikoo_",
       "hakureico",
       "xixi_yuexi",
       "Jennife80677612"


### PR DESCRIPTION
Fix the typo introduced in [one-among-us/data#274 `data/eggs.json` R101](https://github.com/one-among-us/data/pull/274/files#diff-99ebebf91a42d322dd826054408480a97a52356b2952e84315ed7921178b4495R101) which was [one-among-us/web#59 `src/logic/easterEgg.ts` L206](https://github.com/one-among-us/web/pull/59/files#diff-dbc6eec90ccad36845f9a1a19077926f4459855e35d6f054a6d3fc543a775ef5L206)